### PR TITLE
Updated the Tarugoff video reference

### DIFF
--- a/_includes/layouts/tarugoff.njk
+++ b/_includes/layouts/tarugoff.njk
@@ -23,9 +23,9 @@ scripts:
     </header>
 
     <figure class="maincontent-photo">
-      <tarugo-video id="video" data-id="456634375" title="#tarugoff">
+      <tarugo-video id="video" data-id="562113999" title="#tarugoff">
         <img src="/img/tarugoff-video-overlay.jpeg">
-        <a href="https://vimeo.com/456634375">#tarugoff</a>
+        <a href="https://vimeo.com/562113999">#tarugoff</a>
       </tarugo-video>
     </figure>
 


### PR DESCRIPTION
With this PR the video shown at the Tarugoff page has the information and logos updated.